### PR TITLE
Safeguard design intent access

### DIFF
--- a/openshape/lib/designHistory.js
+++ b/openshape/lib/designHistory.js
@@ -89,7 +89,17 @@ class DesignHistoryManager {
     
     // Update parameters
     operation.parameters = { ...operation.parameters, ...newParameters };
-    if (this.designIntent[operationId]) {
+    
+    // Ensure designIntent entry exists and update parameters
+    if (!this.designIntent[operationId]) {
+      // Initialize missing designIntent entry with minimal structure
+      this.designIntent[operationId] = {
+        intent: 'No intent recorded',
+        operation: operation.toolName || operation.name || 'unknown',
+        parameters: operation.parameters,
+        dependencies: []
+      };
+    } else {
       this.designIntent[operationId].parameters = operation.parameters;
     }
 

--- a/openshape/lib/designHistory.js
+++ b/openshape/lib/designHistory.js
@@ -89,7 +89,9 @@ class DesignHistoryManager {
     
     // Update parameters
     operation.parameters = { ...operation.parameters, ...newParameters };
-    this.designIntent[operationId].parameters = operation.parameters;
+    if (this.designIntent[operationId]) {
+      this.designIntent[operationId].parameters = operation.parameters;
+    }
 
     console.log(`Updating operation ${operationId} parameters:`, {
       old: oldParameters,

--- a/openshape/lib/mcpTools.js
+++ b/openshape/lib/mcpTools.js
@@ -176,7 +176,7 @@ const registerDesignHistoryTools = () => {
         );
         
         // Record the intent if provided
-        if (params.intent) {
+        if (params.intent && designHistory.designIntent[params.operationId]) {
           designHistory.designIntent[params.operationId].intent += ` | Updated: ${params.intent}`;
         }
         

--- a/openshape/lib/mcpTools.js
+++ b/openshape/lib/mcpTools.js
@@ -176,8 +176,13 @@ const registerDesignHistoryTools = () => {
         );
         
         // Record the intent if provided
-        if (params.intent && designHistory.designIntent[params.operationId]) {
-          designHistory.designIntent[params.operationId].intent += ` | Updated: ${params.intent}`;
+        if (params.intent) {
+          if (designHistory.designIntent[params.operationId]) {
+            designHistory.designIntent[params.operationId].intent += ` | Updated: ${params.intent}`;
+          } else {
+            // This shouldn't happen after the designHistory fix, but defensive programming
+            console.warn(`DesignIntent entry missing for operation ${params.operationId}, intent not recorded`);
+          }
         }
         
         return {


### PR DESCRIPTION
Fixes `TypeError` by validating access to `designHistory.designIntent` properties in `mcpTools.js` and `designHistory.js`.

---
<a href="https://cursor.com/background-agent?bcId=bc-100b0189-5035-45ab-8907-37295543a5d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-100b0189-5035-45ab-8907-37295543a5d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

